### PR TITLE
Add .gemrc and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # short-stack
 Our delicious development stack, fully automated.
 
-# Install
+## Install
 `bash <(curl -s curl -L https://raw.githubusercontent.com/poetic/short-stack/master/install.sh)`
+
+## Details
+
+Short Stack is being built and tested on OSX Yosemite (10.10.x)

--- a/roles/common/files/.gemrc
+++ b/roles/common/files/.gemrc
@@ -1,0 +1,1 @@
+gem: --no-rdoc --no-ri

--- a/roles/common/tasks/ruby.yml
+++ b/roles/common/tasks/ruby.yml
@@ -3,3 +3,8 @@
   copy:
     src: .short-stack/vimrc.d/ruby.bundle
     dest: ~/.short-stack/vimrc.d/ruby.bundle
+- name: copy .gemrc into ~
+  copy:
+    src: .gemrc
+    dest: ~/.gemrc
+


### PR DESCRIPTION
the .gemrc makes `gem install` skip installing docs. Solves [#7](https://github.com/poetic/short-stack/issues/7)
